### PR TITLE
Feature: Report dropped columns due to NaN (Issue #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The project (and the examples) live on GitHub:
 
 * https://github.com/ianozsvald/discover_feature_relationships
 
+Information on the number of dropped columns per (feature, target) tuple can be returned upon request.
+
 ## Titanic example
 
 [Titanic Notebook](./examples/example_titanic_discover_feature_relationships.ipynb)

--- a/discover_feature_relationships/discover.py
+++ b/discover_feature_relationships/discover.py
@@ -14,8 +14,15 @@ def labelencode_if_object(df_ml):
             df_ml[col] = replacement_series
     return df_ml
 
-def discover(df, classifier_overrides=None, method="rf", random_state=None):
-    """TODO describe what we're doing here"""
+def discover(df, classifier_overrides=None, method="rf", random_state=None, include_na_information=False):
+    """Discover relationships for each pair of columns in the dataframe.
+    :param classifier_overrides set which columns should be treated as classification problems
+    :param method method to use to discover relationships. Currently one of pearson, spearman, kendall or rf
+    :param random_state optional, used to initialize the classifier/regressor
+    :param include_na_information Include information on the number of dropped columns per column tuple
+    :returns a single result dataframe if include_na_information is False. Otherwise returns a tuple
+      of dataframes (df_results, df_na_info)
+    """
     corr_methods = ["pearson", 'spearman', 'kendall']
     known_methods = corr_methods + ['rf']
     assert method in set(known_methods), f"Expecting method to be one of: {known_methods}"
@@ -31,6 +38,7 @@ def discover(df, classifier_overrides=None, method="rf", random_state=None):
         estimator_mapping[col] = est
 
     ds = []
+    nan_information = []
     for idx_Y, target in enumerate(cols):
         est = estimator_mapping[target]
         for idx_X, feature in enumerate(cols):
@@ -41,9 +49,10 @@ def discover(df, classifier_overrides=None, method="rf", random_state=None):
             rows_before_drop_na = df_ml.shape[0]
             df_ml = df_ml.dropna()
             rows_after_drop_na = df_ml.shape[0]
-            #if rows_after_drop_na < rows_before_drop_na:
-            #    print(feature, target)
-            #    print(f"Dropped {rows_before_drop_na - rows_after_drop_na} rows")
+            n_dropped_na = rows_before_drop_na - rows_after_drop_na
+            nan_info = {'feature' : feature , 'target' : target, 'n_dropped_na' : n_dropped_na,
+                        'pct_dropped_na' : (n_dropped_na / rows_before_drop_na)}
+            nan_information.append(nan_info)
 
             df_ml = labelencode_if_object(df_ml)
 
@@ -75,7 +84,11 @@ def discover(df, classifier_overrides=None, method="rf", random_state=None):
             ds.append(d)
 
     df_results = pd.DataFrame(ds)
-    return df_results
+    df_nan_info = pd.DataFrame(nan_information)
+    if include_na_information:
+        return df_results, df_nan_info
+    else:
+        return df_results
 
 if __name__ == "__main__":
     # simple test to make sure the code is running
@@ -91,3 +104,9 @@ if __name__ == "__main__":
     df_results = discover(X, method="kendall")
     print(df_results)
     assert (df_results.query("feature=='b' and target=='c'")['score'].iloc[0]) >= 0.99, "Expect b to predict c"
+
+    X.iloc[0,0] = np.nan
+    df_results, df_nan_info = discover(X, include_na_information=True)
+    print(df_results)
+    print(df_nan_info)
+    assert (df_nan_info.query("feature=='a' and target=='b'")['n_dropped_na'].iloc[0]) == 1, "(a,b) should drop one column"

--- a/test_discover.py
+++ b/test_discover.py
@@ -11,3 +11,17 @@ def test1():
     print(df_results)
     assert (df_results.query("feature=='b' and target=='a'")['score'].iloc[0]) == 1, "Expect b to predict a"
     assert (df_results.query("feature=='a' and target=='b'")['score'].iloc[0]) <= 0, "Expect a not to predict b"
+
+
+def test_na_info():
+    """Check a 3 column dataframe with missing data. Make sure number of dropped columns is reported correctly"""
+    X = pd.DataFrame({'a': np.ones(10),
+                      'b': np.arange(0, 10),
+                      'c': np.arange(0, 20, 2)})
+    X.iloc[0,0] = np.nan
+    X.iloc[2,0] = None
+    X.iloc[1,1] = pd.NaT
+    _, df_info = discover(X, include_na_information=True)
+    assert (df_info.query("feature=='a' and target=='b'")['n_dropped_na'].iloc[0] == 3), "Expect (a,b) to drop 3 rows"
+    assert (df_info.query("feature=='c' and target=='b'")['n_dropped_na'].iloc[0] == 1), "Expect (c,b) to drop 1 row"
+    assert (df_info.query("feature=='a' and target=='c'")['n_dropped_na'].iloc[0] == 2), "Expect (a,c) to drop 1 row"


### PR DESCRIPTION
**Feature**
Add a new feature enabling the reporting of the number of dropped columns
per (feature, target) tuple due to missing data.

**Implementation**
discover() gets a new flag 'include_na_information'. If this flag is set to true it returns a tuple of dataframes (results, information). Defaults to False to keep backward compatibility.

Includes a new test and slightly updated readme. None of the examples are updated (yet).